### PR TITLE
Rewrite the test cases for groups

### DIFF
--- a/api/interestr/api/models.py
+++ b/api/interestr/api/models.py
@@ -47,10 +47,10 @@ class Group(BaseModel):
     name = models.CharField(max_length=40)
     description = models.TextField(blank=True, default='')
     location = models.TextField(blank=True, default='')
-    tags = models.ManyToManyField(Tag, related_name='groups')
+    tags = models.ManyToManyField(Tag, blank=True, related_name='groups')
     is_private = models.BooleanField(blank=True, default=False)
-    members = models.ManyToManyField(auth_models.User, related_name='joined_groups')
-    moderators = models.ManyToManyField(auth_models.User, related_name='moderated_groups')
+    members = models.ManyToManyField(auth_models.User, blank=True, related_name='joined_groups')
+    moderators = models.ManyToManyField(auth_models.User, blank=True, related_name='moderated_groups')
     picture = models.ImageField(blank=True, null=True)
 
     def __str__(self):

--- a/api/interestr/api/serializers.py
+++ b/api/interestr/api/serializers.py
@@ -21,8 +21,9 @@ class GroupSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = core_models.Group
-        fields = ('id', 'name', 'created', 'updated', 'size', 'members', 'moderators', 'picture', 'data_templates',
-                  'tags', )
+        fields = ('id', 'name', 'created', 'updated', 'size', 'members',
+         'moderators', 'picture', 'data_templates', 'tags', )
+        read_only_fields = ('members', 'moderators',)
 
 class UserSerializer(serializers.ModelSerializer):
     joined_groups = GroupSerializer(many=True, read_only=True)

--- a/api/interestr/api/tests.py
+++ b/api/interestr/api/tests.py
@@ -85,8 +85,7 @@ class GroupTests(TestCase):
         response = self.client.put(test_url, follow=True)
         self.assertEqual(response.status_code, 410)
 
-    def test_3_remove_users_to_group(self):
-        # add 2 users, remove the last one.
+    def test_3_remove_users_from_group(self):
         self.test_group.members.add(self.test_user1)
         self.test_group.members.add(self.test_user2)
         test_group_id = self.test_group.id
@@ -101,7 +100,6 @@ class GroupTests(TestCase):
 
 
     def test_4_remove_nonexistant_users_from_group(self):
-        #adds 1 user, tries to remove the other.
         self.test_group.members.add(self.test_user1)
         test_group_id = self.test_group.id
         test_url = '/api/v1/users/groups/' + str(test_group_id) + '/'       

--- a/api/interestr/api/urls.py
+++ b/api/interestr/api/urls.py
@@ -16,8 +16,8 @@ urlpatterns = [
     url(r'^data_templates/$', views.DataTemplateList.as_view(), name='datatemplates'),
     url(r'^data_templates/(?P<pk>\d+)/$', views.DataTemplateDetail.as_view(), name='datatemplatedetail'),
     url(r'^groups/$', views.GroupList.as_view(), name='groups'),
-    url(r'^groups/(?P<pk>\d+)/$', views.GroupDetail.as_view(), name='groupDetail'),
+    url(r'^groups/(?P<pk>\d+)/$', views.GroupDetail.as_view(), name='groupdetail'),
 
-    url(r'^users/groups/(?P<pk>\d+)/$', views.memberGroupOperation, name='groupOperation'),
+    url(r'^users/groups/(?P<pk>\d+)/$', views.MemberGroupOperation.as_view(), name='groupoperation'),
     url(r'^search_wiki/$', views.search_wikidata),
 ]

--- a/api/interestr/api/views.py
+++ b/api/interestr/api/views.py
@@ -4,7 +4,11 @@ from __future__ import unicode_literals
 from rest_framework.authtoken.models import Token
 from rest_framework import generics
 from rest_framework.decorators import api_view
+from rest_framework.views import APIView
+from rest_framework.permissions import IsAuthenticated
+
 from django.shortcuts import render
+
 
 from django.http import HttpResponse, JsonResponse
 
@@ -157,42 +161,26 @@ class TagDetail(generics.RetrieveUpdateDestroyAPIView):
 
 ### Detail Views END
 
-@api_view(['PUT', 'DELETE'])
-def memberGroupOperation(request, pk):
-    """
-    Removes or adds the authenticated user from/to the group
-    whose id is pk.
-    """
-    #check auth
-    try:
+class MemberGroupOperation(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    def put(self, request, pk):
         group = core_models.Group.objects.get(pk=pk)
-    except core_models.Group.DoesNotExist:
-        return HttpResponse(status=404)
-
-    # get authenticated user.
-    user = request.user
-    if not user.is_authenticated():
-        return HttpResponse(status=403)
-
-    if request.method == 'PUT':
-        if group.members.filter(id=user.id).count() == 1:
-            # handle, user is already a member.
+        # handle, user is already a member.
+        if group.members.filter(id=request.user.id).count() == 1:
             return HttpResponse(status=410)
-        else:
-            group.members.add(user)
-            group.save()
-            serializer = core_serializers.GroupSerializer(group)
-            return JsonResponse(serializer.data)
+        group.members.add(request.user);    group.save()
+        serializer = core_serializers.GroupSerializer(group)
+        return JsonResponse(serializer.data)
 
-    elif request.method == 'DELETE':
-        if group.members.filter(id=user.id).count() == 0:
-            # handle, user isn't a member to begin with.
+    def delete(self, request, pk):
+        group = core_models.Group.objects.get(pk=pk)
+        # handle, user isn't a member to begin with.
+        if group.members.filter(id=request.user.id).count() == 0:
             return HttpResponse(status=410)
-        else:
-            group.members.remove(user)
-            group.save()
-            serializer = core_serializers.GroupSerializer(group)
-            return JsonResponse(serializer.data)
+        group.members.remove(request.user); group.save()
+        serializer = core_serializers.GroupSerializer(group)
+        return JsonResponse(serializer.data)
 
 @api_view(['GET'])
 def search_wikidata(request, limit=15):


### PR DESCRIPTION
# About

* **Related Issues:** #96, #133 

### Changes

- Rewritten the group tests. #96 
- We now have a class based group-operation view. #96
- group-operation route now has a name field. #96
- We can now create a group with empty members & moderators fields. #133 
- Changed moderators and members fields to read only in the group serializer (I saw the other guy said he did this in #137 too, but I couldn't see where he changed it. So I modified the serializer as well :$ ). #133 

Closes #133 