### PR TITLE
Implement the search frontend and backend

### DIFF
--- a/api/interestr/api/views.py
+++ b/api/interestr/api/views.py
@@ -85,7 +85,7 @@ class DataTemplateList(generics.ListCreateAPIView):
     """
     serializer_class = core_serializers.DataTemplateSerializer
     pagination_class = DataTemplateLimitOffSetPagination
-    
+
     def get_queryset(self):
         """
         Optionally restricts the returned purchases to a given user,
@@ -106,7 +106,7 @@ class PostList(generics.ListCreateAPIView):
     post:
     Create a new data post instance.
     """
-    
+
     serializer_class = core_serializers.PostSerializer
     pagination_class = PostLimitOffsetPagination
 

--- a/api/interestr/website/static/assets/css/custom.css
+++ b/api/interestr/website/static/assets/css/custom.css
@@ -2,6 +2,10 @@
   height: 90px;
 }
 
+:focus {
+  outline: none !important;
+}
+
 html, body {
   height: 100%;
 }

--- a/api/interestr/website/templates/website/base.html
+++ b/api/interestr/website/templates/website/base.html
@@ -39,6 +39,24 @@
       }
       return cookieValue;
     }
+    window.onload = function() {
+      window.search = function() {
+        var searchQuery = $("#search-input").val();
+        if (!searchQuery.length) {
+          swal('Sorry...', 'Please enter at least 1 character to search.', 'error');
+          return;
+        }
+        window.location.href = "{% url 'website:search' %}?q=" + searchQuery;
+      }
+
+      // Search on enter
+      $("#search-input").on('keydown', function(e) {
+        if (e.keyCode === 13) {
+          e.preventDefault();
+          window.search();
+        }
+      })
+    }
   </script>
 </head>
 

--- a/api/interestr/website/templates/website/create-group.html
+++ b/api/interestr/website/templates/website/create-group.html
@@ -6,10 +6,10 @@
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
     <li class="nav-search">
-      <input type="text" value="" class="form-control" placeholder="Search...">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
     </li>
     <li>
-      <a href="javascript:void(0);">
+      <a href="javascript:void(0);" onclick="window.search()">
         <i class="fa fa-search"></i>
       </a>
     </li>

--- a/api/interestr/website/templates/website/group-details.html
+++ b/api/interestr/website/templates/website/group-details.html
@@ -8,10 +8,10 @@
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
     <li class="nav-search">
-      <input type="text" value="" class="form-control" placeholder="Search...">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
     </li>
     <li>
-      <a href="javascript:void(0);">
+      <a href="javascript:void(0);" onclick="window.search()">
         <i class="fa fa-search"></i>
       </a>
     </li>
@@ -262,7 +262,7 @@
     templateName = document.getElementById('templateName');
     formFields = document.getElementById('formFields');
     currentTemplateText = document.getElementById('currentTemplateText');
-	
+
 
 function createTemplateOnClick() {
         templateName.value = '';
@@ -657,7 +657,7 @@ function createTemplateOnClick() {
             var divLabel = document.createElement('div');
             divLabel.classList.add('template-input-label', 'checkbox');
             divLabel.innerHTML = label.innerHTML;
-if(e.which == 13 && !e.shiftKey) {        
+if(e.which == 13 && !e.shiftKey) {
         $(this).closest("form").submit();
         e.preventDefault();
         return false;
@@ -776,13 +776,13 @@ if(e.which == 13 && !e.shiftKey) {
     }
 
 function submitComment(e, commentText){
-	
+
 if(e.which == 13 && !e.shiftKey) {
             $.ajax({
           method: 'POST',
           url: '{% url "api:comments" %}',
           data: {
-	      text: commentText.value, 
+	      text: commentText.value,
               post: commentText.id.replace('comment-text-post-',''),
               owner: '{{ user.id }}',
           },
@@ -792,7 +792,7 @@ if(e.which == 13 && !e.shiftKey) {
           location.reload();
         }).fail((xhr, status, err) => swal('Oops...', 'Unexpected error, couldn\'t send the comment.', 'error'));
 
- 
+
         e.preventDefault();
         return false;
     }

--- a/api/interestr/website/templates/website/groups.html
+++ b/api/interestr/website/templates/website/groups.html
@@ -6,10 +6,10 @@
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
     <li class="nav-search">
-      <input type="text" value="" class="form-control" placeholder="Search...">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
     </li>
     <li>
-      <a href="javascript:void(0);">
+      <a href="javascript:void(0);" onclick="window.search()">
         <i class="fa fa-search"></i>
       </a>
     </li>

--- a/api/interestr/website/templates/website/news.html
+++ b/api/interestr/website/templates/website/news.html
@@ -6,10 +6,10 @@
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
     <li class="nav-search">
-      <input type="text" value="" class="form-control" placeholder="Search...">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
     </li>
     <li>
-      <a href="javascript:void(0);">
+      <a href="javascript:void(0);" onclick="window.search()">
         <i class="fa fa-search"></i>
       </a>
     </li>
@@ -36,7 +36,7 @@
     <div class="news">
       {% if object_list %}
         {% for news_item in object_list %}
-        
+
         {% endfor %}
       {% else %}
         No news to show!

--- a/api/interestr/website/templates/website/search.html
+++ b/api/interestr/website/templates/website/search.html
@@ -1,0 +1,82 @@
+{% extends 'website/base.html' %}
+
+{% block title %}Groups{% endblock %}
+
+{% block navbaritems %}
+<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+  <ul class="nav navbar-nav navbar-right">
+    <li class="nav-search">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
+    </li>
+    <li>
+      <a href="javascript:void(0);" onclick="window.search()">
+        <i class="fa fa-search"></i>
+      </a>
+    </li>
+    <li class="dropdown">
+      <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ user.username }}<b class="caret"></b></a>
+      <ul class="dropdown-menu">
+        <li><a href="{% url 'website:news' %}">News Feed</a></li>
+        <li><a href="{% url 'website:groups' %}">Groups</a></li>
+        <li class="divider"></li>
+        <li><a href="{% url 'website:logout' %}">Logout</a></li>
+      </ul>
+    </li>
+  </ul>
+</div>
+{% endblock %}
+
+{% block content %}
+
+<div class="main">
+  <div class="container">
+    <h1>Groups</h1>
+    <hr>
+
+    <div class="groups">
+      {% if groups %}
+        {% for group in groups %}
+        <div class="group">
+          <a href="{% url 'website:group_details' group.id %}">
+            <div class="group-image">
+              <img src="{{ group.get_picture }}" alt="Group alt..." width='160' class="img-thumbnail img-responsive">
+            </div>
+          </a>
+          <div class="group-info">
+            <a href="{% url 'website:group_details' group.id %}">
+              <div class="group-name">
+                <h4>{{ group.name }}</h4>
+              </div>
+            </a>
+            <div class="group-member-count">
+              {{ group.size }} member{{ group.size|pluralize }}
+            </div>
+            <div class="group-description">
+              {{ group.description }}
+            </div>
+          </div>
+        </div>
+        {% endfor %}
+      {% else %}
+        No groups found!
+      {% endif %}
+    </div>
+
+    <h1>Users</h1>
+    <hr>
+
+    <div class="users">
+      {% if users %}
+        {% for user in users %}
+        <div class="user">
+          {{ user.username }}
+        </div>
+        {% endfor %}
+      {% else %}
+        No users found!
+      {% endif %}
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/api/interestr/website/urls.py
+++ b/api/interestr/website/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     url(r'^groups/$', views.GroupView.as_view(), name='groups'),
     url(r'^logout/$', views.LogoutView.as_view(), name='logout'),
     url(r'^news/$', views.NewsView.as_view(), name='news'),
+    url(r'^search/$', views.SearchView.as_view(), name='search'),
     url(r'^groups/(?P<pk>\d+)/$', views.GroupDetailsView.as_view(), name='group_details'),
     url(r'^groups/create/$', views.CreateGroupView.as_view(), name='create_group'),
 ]

--- a/api/interestr/website/views.py
+++ b/api/interestr/website/views.py
@@ -18,6 +18,7 @@ from api.models import Group
 from .forms import LoginForm, RegisterForm, CreateGroupForm
 
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db.models import Q
 
 class UserLoginView(View):
     form_class = LoginForm
@@ -46,16 +47,16 @@ class UserLoginView(View):
                                 username = User.objects.get(email=username_or_email).username
                         else:
                                 username = username_or_email
-                        
+
                         user = authenticate(username=username, password=password)
                 except:
-                        user = None 
+                        user = None
 
                 if user is not None:
-                        if user.is_active: #if he/she is not banned 
+                        if user.is_active: #if he/she is not banned
                                 login(request,user)
-                                return redirect('website:groups') 
-                
+                                return redirect('website:groups')
+
                 return render(request,self.template_name, {'err_msg': 'Invalid credentials!'})
 
 class UserRegisterView(View):
@@ -160,3 +161,15 @@ class NewsView(LoginRequiredMixin, generic.ListView):
 
     def get_queryset(self):
         return None
+
+class SearchView(LoginRequiredMixin, generic.ListView):
+    template_name = 'website/search.html'
+
+    def get(self, request):
+        query = self.request.GET.get("q")
+        groups = Group.objects.all()
+        users = User.objects.all()
+        if query:
+            groups = groups.filter(Q(name__icontains=query)).distinct()
+            users = users.filter(Q(username__icontains=query)).distinct()
+        return render(request, self.template_name, {'groups': groups, 'users': users, 'search_term': query})


### PR DESCRIPTION
## About

* **Related Pull Requests:** #140 

Implement a basic search view and its frontend. I didn't use the existing search endpoints (actually, listing endpoints with filtering feature) because creating a new view felt easier.

### Changes

- Implement a basic search view which just filters the users by their usernames and groups by their names, with a given a search term. (query term `q`)
- Implement a basic listing frontend for the search results.

## Visuals

### Search Page
Not my magnum opus, but it does the job.
![screencapture-localhost-8000-search-1512002752342](https://user-images.githubusercontent.com/13895224/33407199-467fa0b8-d581-11e7-896e-e23c06618000.png)

## Testing

- Log in and enter a search term to the search box in the navbar.
- Click on the magnifying glass icon or press enter on the input.
- You should be redirected to a search page where you should see the search results: groups that contain the search term in their names, and users on their usernames.
