### PR TITLE
Votecaster and comments fixes

### DIFF
--- a/api/interestr/website/static/assets/css/custom.css
+++ b/api/interestr/website/static/assets/css/custom.css
@@ -197,8 +197,16 @@ small {
   margin: 0;
 }
 
-.group-detail-content .comments {
+.group-detail-content .comments-header {
   text-align: right;
+}
+
+.votecaster, .comments-header {
+  flex-grow: 1;
+}
+
+.comments-contents {
+  padding-top: 10px;
 }
 
 .avatar {

--- a/api/interestr/website/templates/website/group-details.html
+++ b/api/interestr/website/templates/website/group-details.html
@@ -297,6 +297,8 @@
 
       {% for post in group.posts.all reversed %}
       <div class="group-detail-content">
+
+        <!-- Post Start -->
         <div class="header">
           <div class="text">
             <p class="title"><strong>{{ post.owner.username }}</strong></p>
@@ -311,32 +313,41 @@
           <p><strong>{{ question_response.question }}</strong>: <span>{{ question_response.response }}</span></p>
           {% endfor %}
         </div>
-        <div data-post-id="{{ post.id }}" data-vote-id="{{ post|vote_of_user:user.id }}" class="col-md-6">
-          <span class="vote-count">{{ post.vote_sum }}</span>
-          <span title="+1 Vote Up" class="fa fa-chevron-up vote vote-up"></span>
-          <span title="-1 Vote Down" class="fa fa-chevron-down vote vote-down"></span>
-        </div><script type="text/javascript">votecaster_onload(document.currentScript.previousSibling);</script>
-        <div class="col-md-6 comments">
-          <a class="text-muted" href="javascript:void(0);">0 Comments</a>
-        </div>
-        <div class="comments">
-      		<div class="comments-header" onclick="$(this).next().slideToggle()" ><span>{{ post.comments.count }} Comments</span>
+        <!-- Post Start -->
 
+        <div style="display: flex">
+          <!-- Votes Start -->
+          <div data-post-id="{{ post.id }}" data-vote-id="{{ post|vote_of_user:user.id }}" class="votecaster">
+            <span class="vote-count">{{ post.vote_sum }}</span>
+            <span title="+1 Vote Up" class="fa fa-chevron-up vote vote-up"></span>
+            <span title="-1 Vote Down" class="fa fa-chevron-down vote vote-down"></span>
+          </div><script type="text/javascript">votecaster_onload(document.currentScript.previousSibling);</script>
+          <!-- Votes Start -->
+
+          <!-- Comments Header Start -->
+          <div class="comments-header">
+        		<a onclick="$(this).parent().parent().next().slideToggle()" href="javascript:void(0);">
+              {{ post.comments.count }} Comments
+            </a>
           </div>
-      		<div class="comments-contents" style="display: none">
+          <!-- Comments Header End -->
+        </div>
 
-      		  <div class="form-group" id="commentForm{{post.id}}">
-      		    <input name="text" class="form-control" id="comment-text-post-{{post.id}}" type="text" onkeypress="submitComment(event,this)" placeholder="Press Enter to send your comment!">
-      		  </div>
+        <!-- Comments Contents Start -->
+        <div class="comments-contents" style="display: none">
+          <div class="form-group" id="commentForm{{post.id}}">
+            <input name="text" class="form-control" id="comment-text-post-{{post.id}}" type="text" onkeypress="submitComment(event,this)" placeholder="Press Enter to send your comment!">
+          </div>
 
-      		  <div class="comments-old-contents" style="text-align: left">
-                {% for comment in post.comments.all%}
-      	           <hr> </hr>
-      	           <p style="font-size: 14px">{{ comment.text}} - <span style="color: #3af">{{comment.owner.username }}</span> <span style="color: #9199a1">{{comment.created}}</span></p>
-                {% endfor %}
-      	    </div>
+          <div class="comments-old-contents" style="text-align: left">
+              {% for comment in post.comments.all%}
+                 <hr> </hr>
+                 <p style="font-size: 14px">{{ comment.text }} - <span style="color: #3af">{{comment.owner.username }}</span> <span style="color: #9199a1">{{comment.created}}</span></p>
+              {% endfor %}
           </div>
         </div>
+        <!-- Comments Contents End -->
+
       </div>
       {% endfor %}
 		</div>

--- a/api/interestr/website/templates/website/group-details.html
+++ b/api/interestr/website/templates/website/group-details.html
@@ -324,7 +324,7 @@
 
           <!-- Comments Header Start -->
           <div class="comments-header">
-        		<a onclick="$(this).parent().parent().next().slideToggle()" href="javascript:void(0);">
+        		<a class="text-muted" onclick="$(this).parent().parent().next().slideToggle()" href="javascript:void(0);">
               {{ post.comments.count }} Comment{{ post.comments.count|pluralize }}
             </a>
           </div>

--- a/api/interestr/website/templates/website/group-details.html
+++ b/api/interestr/website/templates/website/group-details.html
@@ -182,13 +182,14 @@
           var basevote = 0;
 
           function refresh_current_vote() {
+            casteractive = false;
+            basevote = parseInt(counter.textContent, 10) || 0;
+
             if (voteid == absent_voteid) {
               caststatus = null;
               casteractive = true;
             }
             else {
-              casteractive = false;
-
               $.ajax({
                 method: 'GET',
                 url: '{% url "api:votedetail" 12345 %}'.replace(/12345/, voteid),
@@ -201,13 +202,10 @@
                   update_buttons();
 
                   if (caststatus === true) {
-                    basevote = (parseInt(counter.textContent, 10) || 0) - 1;
+                    basevote -= 1;
                   }
                   else if (caststatus === false) {
-                    basevote = (parseInt(counter.textContent, 10) || 0) + 1;
-                  }
-                  else {
-                    basevote = (parseInt(counter.textContent, 10) || 0);
+                    basevote += 1;
                   }
 
                   casteractive = true;

--- a/api/interestr/website/templates/website/group-details.html
+++ b/api/interestr/website/templates/website/group-details.html
@@ -327,7 +327,7 @@
           <!-- Comments Header Start -->
           <div class="comments-header">
         		<a onclick="$(this).parent().parent().next().slideToggle()" href="javascript:void(0);">
-              {{ post.comments.count }} Comments
+              {{ post.comments.count }} Comment{{ post.comments.count|pluralize }}
             </a>
           </div>
           <!-- Comments Header End -->


### PR DESCRIPTION
## About

* **Related Issues:** #163 and #164 

We had some minor bugs on the web-frontend in yesterday's demo. They were due to a hastily done merge which included the voting feature. Luckily it did not break anything altogether, and we only had some minor, hardly noticeable issues.

This fix aims to fix those issues. You can see them on the related issues.

### Changes

- United the goods of the two comments buttons, made them into one.
- Fixed the problem with the voting, occurred when the user is voting a post for the first time, and to a post that already had non-zero votes.

## Visuals

![votesandcomments](https://user-images.githubusercontent.com/6666524/33488676-7176a1da-d6c2-11e7-8422-26ad2c8fa69b.png)

## Testing

How can this contribution be tested? Use the following structure:

### Commenting
- Try opening the comments-contents box using the comments label.
- Try inserting a comment.
- Do it (again) on a post without any comments, observe the label changing from "0 comment**s**" to "1 comment".
- Comment again on that same post, see the label getting pluralized.

### Voting
- Vote a post, make it have a vote other than 0.
- (Sign up and) login with another user.
- Verify that the post has nonzero votes by looking at the counter.
- Vote the same post again with the new user.
- See if the vote count changes properly, and not into 1 or -1, as if the post had 0 votes.