### PR TITLE
Improvement/api reduce data

### DIFF
--- a/api/interestr/api/serializers.py
+++ b/api/interestr/api/serializers.py
@@ -3,7 +3,37 @@ from rest_framework import serializers
 from . import models as core_models
 from django.contrib.auth import models as auth_models
 
+#===Mid level serializers===
+# These will help us display the data much better with
+# the other serializers.
+
+class UserIdNameSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = auth_models.User
+        fields = ('id', 'username', )
+
+
+class GroupIdNameDescriptionSerializer(serializers.ModelSerializer):
+    
+    class Meta:
+        model = core_models.Group
+        fields = ('id', 'name', 'description', )
+
+class DataTemplateIdNameFieldsSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = core_models.DataTemplate
+        fields = ('id', 'name', 'fields', )
+
+#END
+#===Mid level serializers===
+
+
+
 class DataTemplateSerializer(serializers.ModelSerializer):
+    user = UserIdNameSerializer()
+    group = GroupIdNameDescriptionSerializer()
 
     class Meta:
         model = core_models.DataTemplate
@@ -14,14 +44,14 @@ class TagSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = core_models.Tag
-        fields = ('id','label', 'url','description', 'concepturi', 'created', 'updated', 'groups' )
+        fields = ('id','label', 'url','description', 'concepturi', 'created', 'updated', )
 
 
 class GroupSerializer(serializers.ModelSerializer):
-    data_templates = DataTemplateSerializer(many=True, read_only=True)
+    data_templates = DataTemplateIdNameFieldsSerializer(many=True, read_only=True)
     tags = TagSerializer(many=True, read_only=True)
-    members = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
-    moderators = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    members = UserIdNameSerializer(many=True, read_only=True)
+    moderators = UserIdNameSerializer(many=True, read_only=True)
 
     class Meta:
         model = core_models.Group
@@ -31,18 +61,23 @@ class GroupSerializer(serializers.ModelSerializer):
 
 
 class CommentSerializer(serializers.ModelSerializer):
+    owner = UserIdNameSerializer()
 
     class Meta:
         model = core_models.Comment
         fields = ('id', 'owner', 'text', 'post', 'created', 'updated',)
 
 class VoteSerializer(serializers.ModelSerializer):
+    owner = UserIdNameSerializer()
 
     class Meta:
         model = core_models.Vote
         fields = ('id', 'owner', 'post', 'up', 'created', 'updated',)
 
 class PostSerializer(serializers.ModelSerializer):
+    owner = UserIdNameSerializer()
+    group = GroupIdNameDescriptionSerializer()
+    data_template = DataTemplateIdNameFieldsSerializer()
     comments = CommentSerializer(many=True, read_only=True)
     votes = VoteSerializer(many=True, read_only=True)
 
@@ -60,15 +95,13 @@ class ProfilePageSerializer(serializers.ModelSerializer):
 
 
 class UserSerializer(serializers.ModelSerializer):
-    joined_groups = GroupSerializer(many=True, read_only=True)
-    moderated_groups = GroupSerializer(many=True, read_only=True)
-    data_templates = DataTemplateSerializer(many=True, read_only=True)
-    comments = CommentSerializer(many=True, read_only=True) 
+    joined_groups = GroupIdNameDescriptionSerializer(many=True, read_only=True)
+    moderated_groups = GroupIdNameDescriptionSerializer(many=True, read_only=True)
+    data_templates = DataTemplateIdNameFieldsSerializer(many=True, read_only=True)
     posts = PostSerializer(many=True, read_only=True)
-    votes = VoteSerializer(many=True, read_only=True)
     profilepage = ProfilePageSerializer(read_only=True, many=False)
 
     class Meta:
         model = auth_models.User
         fields = ('id', 'username', 'email', 'joined_groups', 'moderated_groups',
-         'data_templates', 'posts', 'comments', 'profilepage', 'votes')
+         'data_templates', 'posts', 'profilepage', 'votes', )


### PR DESCRIPTION
## About

I've trimmed the data sent through the API. Below is a full list of changes.

### Changes

- `data_template` field of posts and users now send only `id`, `name` and `fields` fields of the data templates.
- All group list fields of user model now sends only the `id`, `name` and `description` of the groups.
- `/users/` endpoint do not send a list comments anymore.

## Visuals
The data template on the visual is from an old design of my own. Please ignore.
![image](https://user-images.githubusercontent.com/5247569/33529200-619476bc-d87e-11e7-85fc-26df2065d59a.png)
