### PR TITLE
Fix "Improvement/api reduce data"

### DIFF
--- a/api/interestr/api/serializers.py
+++ b/api/interestr/api/serializers.py
@@ -28,6 +28,11 @@ class DataTemplateIdNameFieldsSerializer(serializers.ModelSerializer):
 #END
 #===Mid level serializers===
 
+class DataTemplateSimpleSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = core_models.DataTemplate
+        fields = ('id', 'name', 'group', 'user', 'created', 'updated', 'fields' )
 
 
 class DataTemplateSerializer(serializers.ModelSerializer):

--- a/api/interestr/api/views.py
+++ b/api/interestr/api/views.py
@@ -84,7 +84,7 @@ class DataTemplateList(generics.ListCreateAPIView):
     post:
     Create a new template instance.
     """
-    serializer_class = core_serializers.DataTemplateSerializer
+    serializer_class = core_serializers.DataTemplateSimpleSerializer
     pagination_class = DataTemplateLimitOffSetPagination
 
     def get_queryset(self):

--- a/api/interestr/api/views.py
+++ b/api/interestr/api/views.py
@@ -213,6 +213,13 @@ class DataTemplateDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = core_models.DataTemplate.objects.all()
     serializer_class = core_serializers.DataTemplateSerializer
 
+    def get_serializer_class(self, *args, **kwargs):  
+         try: #without try-catch the api docs will break
+             if self.request.method in ["POST","PUT", "PATCH"]:  
+                 return core_serializers.DataTemplateSimpleSerializer  
+             return core_serializers.DataTemplateSerializer    
+         except:  
+             return core_serializers.DataTemplateSerializer   
 
 class PostDetail(generics.RetrieveUpdateDestroyAPIView):
     """

--- a/api/interestr/website/templates/website/group-details.html
+++ b/api/interestr/website/templates/website/group-details.html
@@ -808,11 +808,6 @@ function createTemplateOnClick() {
             var divLabel = document.createElement('div');
             divLabel.classList.add('template-input-label', 'checkbox');
             divLabel.innerHTML = label.innerHTML;
-if(e.which == 13 && !e.shiftKey) {
-        $(this).closest("form").submit();
-        e.preventDefault();
-        return false;
-    }
             $(label).replaceWith(divLabel);
           });
           templateFields.classList.remove('hidden');

--- a/api/interestr/website/templates/website/group-details.html
+++ b/api/interestr/website/templates/website/group-details.html
@@ -845,7 +845,7 @@ function createTemplateOnClick() {
           url: '{% url "api:datatemplatedetail" 12345 %}'.replace(/12345/, id.toString())
         }).done(function (templateData) {
           currentFields = templateData.fields;
-          if (templateData.group == {{ group.id }}) {
+          if (templateData.group.id == {{ group.id }}) {
             updateFormFields(templateData.fields);
           }
         });


### PR DESCRIPTION
##  About ##
- related pull requests: #171 

In the pull request referenced above, the data template serializer is changed to include basic user and group info. However, since the same endpoint was used for template creation using only id's of group and user, the template creation was broken. This PR is meant to fix this issue.

## Changes ##
- Add another serializer that uses only id's in relations to other objects
- Change the serializer class used depending on the method of the request, i.e.  include user info with GET requests


