### PR TITLE
Post recommendations backend

### DIFF
--- a/api/interestr/api/models.py
+++ b/api/interestr/api/models.py
@@ -38,11 +38,12 @@ class ChoiceEnum(Enum):
 class ProfilePage(BaseModel):
     name = models.CharField(max_length=30, blank=True, default='')
     surname = models.CharField(max_length=30, blank=True, default='')
-    date_of_birth = models.DateField(blank=True, default=datetime.date(1900, 1, 1))
+    date_of_birth = models.DateField(
+        blank=True, default=datetime.date(1900, 1, 1))
     location = models.TextField(blank=True, default='')
     interests = models.TextField(blank=True, default='')
     user = models.OneToOneField(auth_models.User, on_delete=models.CASCADE,
-        verbose_name="user", related_name='profile')
+                                verbose_name="user", related_name='profile')
 
 
 class Tag(BaseModel):
@@ -52,7 +53,7 @@ class Tag(BaseModel):
     description = models.TextField(blank=True, null=True)
 
     def __str__(self):
-        return self.label +' (' + self.concepturi + ')'
+        return self.label + ' (' + self.concepturi + ')'
 
 
 class Group(BaseModel):
@@ -61,8 +62,10 @@ class Group(BaseModel):
     location = models.TextField(blank=True, default='')
     tags = models.ManyToManyField(Tag, blank=True, related_name='groups')
     is_private = models.BooleanField(blank=True, default=False)
-    members = models.ManyToManyField(auth_models.User, blank=True, related_name='joined_groups')
-    moderators = models.ManyToManyField(auth_models.User, blank=True, related_name='moderated_groups')
+    members = models.ManyToManyField(
+        auth_models.User, blank=True, related_name='joined_groups')
+    moderators = models.ManyToManyField(
+        auth_models.User, blank=True, related_name='moderated_groups')
     picture = models.ImageField(blank=True, null=True)
 
     def __str__(self):
@@ -79,9 +82,12 @@ class Group(BaseModel):
 
 
 class Post(BaseModel):
-    owner = models.ForeignKey(auth_models.User, related_name="posts", default=None, null=True)
-    group = models.ForeignKey(Group, related_name='posts', on_delete=models.CASCADE, default=None, null=True)
-    data_template = models.ForeignKey('api.DataTemplate', related_name='posts', default=None, null=True)
+    owner = models.ForeignKey(
+        auth_models.User, related_name="posts", default=None, null=True)
+    group = models.ForeignKey(
+        Group, related_name='posts', on_delete=models.CASCADE, default=None, null=True)
+    data_template = models.ForeignKey(
+        'api.DataTemplate', related_name='posts', default=None, null=True)
     data = JSONField()
 
     def vote_sum(self):
@@ -92,16 +98,20 @@ class Post(BaseModel):
 
 
 class Comment(BaseModel):
-    owner = models.ForeignKey(auth_models.User, related_name="comments", default=None)
+    owner = models.ForeignKey(
+        auth_models.User, related_name="comments", default=None)
     text = models.TextField(default='', blank=True)
     post = models.ForeignKey(Post, related_name='comments', default=None)
 
     def __str__(self):
         return self.text
 
+
 class Vote(BaseModel):
-    owner = models.ForeignKey(auth_models.User, related_name="votes", on_delete=models.CASCADE)
-    post = models.ForeignKey(Post, related_name="votes", on_delete=models.CASCADE)
+    owner = models.ForeignKey(
+        auth_models.User, related_name="votes", on_delete=models.CASCADE)
+    post = models.ForeignKey(Post, related_name="votes",
+                             on_delete=models.CASCADE)
     up = models.NullBooleanField(default=None)
 
     def __str__(self):
@@ -109,10 +119,12 @@ class Vote(BaseModel):
 
     class Meta:
         unique_together = (('owner', 'post'), )
-                
+
+
 class DataTemplate(BaseModel):
     name = models.CharField(max_length=40)
-    group = models.ForeignKey(Group, related_name='data_templates', on_delete=models.SET_NULL, default=None, null=True)
+    group = models.ForeignKey(Group, related_name='data_templates',
+                              on_delete=models.SET_NULL, default=None, null=True)
     user = models.ForeignKey(auth_models.User, related_name='data_templates', on_delete=models.SET_NULL, default=None,
                              null=True)
     fields = JSONField()

--- a/api/interestr/api/urls.py
+++ b/api/interestr/api/urls.py
@@ -35,4 +35,5 @@ urlpatterns = [
     url(r'^users/groups/(?P<pk>\d+)/$', views.MemberGroupOperation.as_view(), name='groupoperation'),
     url(r'^search_wiki/$', views.search_wikidata, name="searchwiki"),
     url(r'^recommend_groups/$', views.recommend_groups, name='recommendgroups'),
+    url(r'^recommend_posts/$', views.recommend_posts, name='recommendposts'),
 ]

--- a/api/interestr/api/views.py
+++ b/api/interestr/api/views.py
@@ -34,6 +34,7 @@ import random
 
 from . import serializers as core_serializers
 from .http import ErrorResponse
+from random import sample
 
 
 # List Views BEGIN
@@ -412,7 +413,7 @@ def recommend_groups(request, limit=5):
     # in case there are not enough candidates as the requested number
     limit = min(len(candidates), limit)
     candidates = list(
-        map(lambda group3: {"id": group3.id, "name": group3.name}, candidates[:limit]))
+        map(lambda group3: {"id": group3.id, "name": group3.name}, sample(candidates, limit)))
     return JsonResponse({"results": candidates})
 
 
@@ -435,7 +436,7 @@ def recommend_posts(request, limit=5):
     # in case there are not enough candidates as the requested number
     limit = min(len(candidates), limit)
     candidates = list(
-        map(lambda post: {"id": post.id, "data": post.data, "owner": post.owner}, candidates[:limit]))
+        map(lambda post: {"id": post.id, "data": post.data, "owner": post.owner.id}, sample(candidates, limit)))
     return JsonResponse({"results": candidates})
 
 


### PR DESCRIPTION
## About

* **Related Issues:** #176

Implemented a basic post recommendation backend that looks at the data templates in common with other posts.

### Changes

- Implement a post recommendation system.
- Return a random sample of recommendations (for both group and post recommendations) in case the recommendation count exceeds the given limit.
- Some linting fixes.

## Visuals

It's not a visual change, but here are some examples from the returned data:

GET: `http://127.0.0.1:8000/api/v1/recommend_posts/`
Response:
```
{"results": [{"owner": 2, "data": [{"question": "Multiselect", "response": "Birds"}, {"question": "Area", "response": "text"}], "id": 2}, {"owner": 2, "data": [{"question": "Text", "response": "text 3"}], "id": 3}]}
```

GET: `http://127.0.0.1:8000/api/v1/recommend_posts/?limit=1`
Response:
```
{"results": [{"owner": 2, "data": [{"question": "Multiselect", "response": "Birds"}, {"question": "Area", "response": "text"}], "id": 2}]}
```

## Testing

- Create some test users with groups and posts.
- Share some posts from all users, using some common templates.
- Login to a user and go to `http://127.0.0.1:8000/api/v1/recommend_posts/` in your browser. (or send a GET request with authentication credentials from some REST client)
- You should see some posts that have been shared using the templates you are using the most.
