### PR TITLE
Group and post recommendations UI

### DIFF
--- a/api/interestr/api/serializers.py
+++ b/api/interestr/api/serializers.py
@@ -71,11 +71,17 @@ class CommentSerializer(serializers.ModelSerializer):
         fields = ('id', 'owner', 'text', 'post', 'created', 'updated',)
 
 class VoteSerializer(serializers.ModelSerializer):
-    owner = UserIdNameSerializer()
+    owner = UserIdNameSerializer(read_only=True)
 
     class Meta:
         model = core_models.Vote
         fields = ('id', 'owner', 'post', 'up', 'created', 'updated',)
+
+class VoteCreateSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = core_models.Vote
+        fields = ('id', 'post', 'up')
 
 class PostSerializer(serializers.ModelSerializer):
     owner = UserIdNameSerializer(read_only=True)

--- a/api/interestr/website/static/assets/css/custom.css
+++ b/api/interestr/website/static/assets/css/custom.css
@@ -273,3 +273,13 @@ div.col-form-legend, div.template-input-label {
 .voted {
   filter: brightness(130%);
 }
+
+.recommended-posts .group-detail-content {
+  padding: 20px;
+  background-color: #f5f5f5;
+  max-width: 800px;
+}
+
+.recommended-posts .group-detail-content:not(:first-of-type) {
+  margin-top: 30px;
+}

--- a/api/interestr/website/templates/website/group-details.html
+++ b/api/interestr/website/templates/website/group-details.html
@@ -167,132 +167,128 @@
       </div>
 
       <script type="text/javascript">
-        function votecaster_onload(votecaster) {
-          var casteractive = false;
+      window.votecaster_onload = function (votecaster) {
+        var casteractive = false;
 
-          var postid = votecaster.getAttribute('data-post-id');
-          var voteid = votecaster.getAttribute('data-vote-id');
-          var absent_voteid = -1;
+        var postid = votecaster.getAttribute('data-post-id');
+        var voteid = votecaster.getAttribute('data-vote-id');
+        var absent_voteid = -1;
 
-          var counter = votecaster.getElementsByClassName('vote-count').item(0);
-          var upcaster = votecaster.getElementsByClassName('vote-up').item(0);
-          var downcaster = votecaster.getElementsByClassName('vote-down').item(0);
+        var counter = votecaster.getElementsByClassName('vote-count').item(0);
+        var upcaster = votecaster.getElementsByClassName('vote-up').item(0);
+        var downcaster = votecaster.getElementsByClassName('vote-down').item(0);
 
-          var caststatus;
-          var basevote = 0;
+        var caststatus;
+        var basevote = 0;
 
-          function refresh_current_vote() {
+        function refresh_current_vote() {
+          casteractive = false;
+          basevote = parseInt(counter.textContent, 10) || 0;
+
+          if (voteid == absent_voteid) {
+            caststatus = null;
+            casteractive = true;
+          }
+          else {
+            $.ajax({
+              method: 'GET',
+              url: '{% url "api:votedetail" 12345 %}'.replace(/12345/, voteid),
+              beforeSend: function(xhr) {
+                xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+              }
+            }).done(function (msg) {
+              if (msg.owner.id == {{ user.id }} && msg.post == postid) {
+                caststatus = msg.up;
+                update_buttons();
+
+                if (caststatus === true) {
+                  basevote -= 1;
+                }
+                else if (caststatus === false) {
+                  basevote += 1;
+                }
+
+                casteractive = true;
+              }
+            });
+          }
+        }
+
+        refresh_current_vote();
+
+        function update_buttons() {
+          if (caststatus === true) {
+            upcaster.classList.add('voted');
+            downcaster.classList.remove('voted');
+          }
+          else if (caststatus === false) {
+            upcaster.classList.remove('voted');
+            downcaster.classList.add('voted');
+          } else {
+            upcaster.classList.remove('voted');
+            downcaster.classList.remove('voted');
+          }
+        }
+
+        upcaster.onclick = function (event) {
+          vote(true);
+        }
+
+        downcaster.onclick = function (event) {
+          vote(false);
+        }
+
+        function vote(up) {
+          if (casteractive) {
             casteractive = false;
-            basevote = parseInt(counter.textContent, 10) || 0;
 
-            if (voteid == absent_voteid) {
+            if (caststatus === up) {
               caststatus = null;
-              casteractive = true;
+              counter.textContent = basevote.toString();
             }
             else {
+              caststatus = up;
+              counter.textContent = (basevote + (up ? 1 : -1)).toString();
+            }
+
+            update_buttons();
+
+            if (voteid == absent_voteid) {
+              // CREATE VOTE, MAKE IT `UP`
               $.ajax({
-                method: 'GET',
-                url: '{% url "api:votedetail" 12345 %}'.replace(/12345/, voteid),
+                method: 'POST',
+                url: '{% url "api:votes" %}',
+                data: {
+                  post: postid,
+                  up: caststatus
+                },
                 beforeSend: function(xhr) {
                   xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
                 }
               }).done(function (msg) {
-                if (msg.owner == {{ user.id }} && msg.post == postid) {
-                  caststatus = msg.up;
-                  update_buttons();
-
-                  if (caststatus === true) {
-                    basevote -= 1;
-                  }
-                  else if (caststatus === false) {
-                    basevote += 1;
-                  }
-
-                  casteractive = true;
+                voteid = msg.id;
+                casteractive = true;
+              });
+            }
+            else {
+              $.ajax({
+                method: 'PATCH',
+                url: '{% url "api:votedetail" 12345 %}'.replace(/12345/, voteid),
+                data: {
+                  post: postid,
+                  up: caststatus
+                },
+                beforeSend: function(xhr) {
+                  xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
                 }
+              }).done(function (msg) {
+                casteractive = true;
               });
             }
           }
-
-          refresh_current_vote();
-
-          function update_buttons() {
-            if (caststatus === true) {
-              upcaster.classList.add('voted');
-              downcaster.classList.remove('voted');
-            }
-            else if (caststatus === false) {
-              upcaster.classList.remove('voted');
-              downcaster.classList.add('voted');
-            } else {
-              upcaster.classList.remove('voted');
-              downcaster.classList.remove('voted');
-            }
-          }
-
-          upcaster.onclick = function (event) {
-            vote(true);
-          }
-
-          downcaster.onclick = function (event) {
-            vote(false);
-          }
-
-          function vote(up) {
-            if (casteractive) {
-              casteractive = false;
-
-              if (caststatus === up) {
-                caststatus = null;
-                counter.textContent = basevote.toString();
-              }
-              else {
-                caststatus = up;
-                counter.textContent = (basevote + (up ? 1 : -1)).toString();
-              }
-
-              update_buttons();
-
-              if (voteid == absent_voteid) {
-                // CREATE VOTE, MAKE IT `UP`
-                $.ajax({
-                  method: 'POST',
-                  url: '{% url "api:votes" %}',
-                  data: {
-                    owner: '{{ user.id }}',
-                    post: postid,
-                    up: caststatus
-                  },
-                  beforeSend: function(xhr) {
-                    xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
-                  }
-                }).done(function (msg) {
-                  voteid = msg.id;
-                  casteractive = true;
-                });
-              }
-              else {
-                // UPDATE THE
-                $.ajax({
-                  method: 'PATCH',
-                  url: '{% url "api:votedetail" 12345 %}'.replace(/12345/, voteid),
-                  data: {
-                    //owner: '{{ user.id }}',
-                    //post: postid,
-                    up: caststatus
-                  },
-                  beforeSend: function(xhr) {
-                    xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
-                  }
-                }).done(function (msg) {
-                  casteractive = true;
-                });
-              }
-            }
-          }
         }
+      }
       </script>
-
       {% for post in group.posts.all reversed %}
       <div class="group-detail-content">
 
@@ -315,17 +311,17 @@
 
         <div style="display: flex">
           <!-- Votes Start -->
-          <div data-post-id="{{ post.id }}" data-vote-id="{{ post|vote_of_user:user.id }}" class="votecaster">
+          <div data-post-id="{{ post.id }}" data-vote-id="{{ post|vote_of_user:user.id }}" id="post-{{post.id}}" class="votecaster">
             <span class="vote-count">{{ post.vote_sum }}</span>
             <span title="+1 Vote Up" class="fa fa-chevron-up vote vote-up"></span>
             <span title="-1 Vote Down" class="fa fa-chevron-down vote vote-down"></span>
-          </div><script type="text/javascript">votecaster_onload(document.currentScript.previousSibling);</script>
+          </div><script type="text/javascript">votecaster_onload(document.getElementById("post-{{post.id}}"));</script>
           <!-- Votes Start -->
 
           <!-- Comments Header Start -->
           <div class="comments-header">
         		<a class="text-muted" onclick="$(this).parent().parent().next().slideToggle()" href="javascript:void(0);">
-              {{ post.comments.count }} Comment{{ post.comments.count|pluralize }}
+              {{ post.comments|length }} Comment{{ post.comments|length|pluralize }}
             </a>
           </div>
           <!-- Comments Header End -->

--- a/api/interestr/website/templates/website/news.html
+++ b/api/interestr/website/templates/website/news.html
@@ -1,5 +1,8 @@
 {% extends 'website/base.html' %}
 
+{% load staticfiles %}
+{% load voting_extras %}
+
 {% block title %}News Feed{% endblock %}
 
 {% block navbaritems %}
@@ -36,12 +39,230 @@
     <hr>
 
     <div class="news">
-      {% if object_list %}
-        {% for news_item in object_list %}
+      {% if news_items %}
+        {% for news_item in news_items %}
 
         {% endfor %}
       {% else %}
         No news to show!
+      {% endif %}
+    </div>
+
+    <h1>Recommended Groups</h1>
+    <hr>
+
+    <div class="recommended-groups">
+      {% if recommended_groups %}
+        {% for group in recommended_groups %}
+        <div class="group">
+          <a href="{% url 'website:group_details' group.id %}">
+            <div class="group-image">
+              <img src="{% static 'assets/img/group_default_icon.png' %}" alt="Group alt..." width='160' class="img-thumbnail img-responsive">
+            </div>
+          </a>
+          <div class="group-info">
+            <a href="{% url 'website:group_details' group.id %}">
+              <div class="group-name">
+                <h4>{{ group.name }}</h4>
+              </div>
+            </a>
+            <div class="group-member-count">
+              {{ group.size }} member{{ group.size|pluralize }}
+            </div>
+            <div class="group-description">
+              {{ group.description }}
+            </div>
+          </div>
+        </div>
+        {% endfor %}
+      {% else %}
+        No recommended groups!
+      {% endif %}
+    </div>
+
+    <h1>Recommended Posts</h1>
+    <hr>
+
+    <script type="text/javascript">
+      window.votecaster_onload = function (votecaster) {
+      var casteractive = false;
+
+      var postid = votecaster.getAttribute('data-post-id');
+      var voteid = votecaster.getAttribute('data-vote-id');
+      var absent_voteid = -1;
+
+      var counter = votecaster.getElementsByClassName('vote-count').item(0);
+      var upcaster = votecaster.getElementsByClassName('vote-up').item(0);
+      var downcaster = votecaster.getElementsByClassName('vote-down').item(0);
+
+      var caststatus;
+      var basevote = 0;
+
+      function refresh_current_vote() {
+        casteractive = false;
+        basevote = parseInt(counter.textContent, 10) || 0;
+
+        if (voteid == absent_voteid) {
+          caststatus = null;
+          casteractive = true;
+        }
+        else {
+          $.ajax({
+            method: 'GET',
+            url: '{% url "api:votedetail" 12345 %}'.replace(/12345/, voteid),
+            beforeSend: function(xhr) {
+              xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+            }
+          }).done(function (msg) {
+            if (msg.owner.id == {{ user.id }} && msg.post == postid) {
+              caststatus = msg.up;
+              update_buttons();
+
+              if (caststatus === true) {
+                basevote -= 1;
+              }
+              else if (caststatus === false) {
+                basevote += 1;
+              }
+
+              casteractive = true;
+            }
+          });
+        }
+      }
+
+      refresh_current_vote();
+
+      function update_buttons() {
+        if (caststatus === true) {
+          upcaster.classList.add('voted');
+          downcaster.classList.remove('voted');
+        }
+        else if (caststatus === false) {
+          upcaster.classList.remove('voted');
+          downcaster.classList.add('voted');
+        } else {
+          upcaster.classList.remove('voted');
+          downcaster.classList.remove('voted');
+        }
+      }
+
+      upcaster.onclick = function (event) {
+        vote(true);
+      }
+
+      downcaster.onclick = function (event) {
+        vote(false);
+      }
+
+      function vote(up) {
+        if (casteractive) {
+          casteractive = false;
+
+          if (caststatus === up) {
+            caststatus = null;
+            counter.textContent = basevote.toString();
+          }
+          else {
+            caststatus = up;
+            counter.textContent = (basevote + (up ? 1 : -1)).toString();
+          }
+
+          update_buttons();
+
+          if (voteid == absent_voteid) {
+            // CREATE VOTE, MAKE IT `UP`
+            $.ajax({
+              method: 'POST',
+              url: '{% url "api:votes" %}',
+              data: {
+                post: postid,
+                up: caststatus
+              },
+              beforeSend: function(xhr) {
+                xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+              }
+            }).done(function (msg) {
+              voteid = msg.id;
+              casteractive = true;
+            });
+          }
+          else {
+            $.ajax({
+              method: 'PATCH',
+              url: '{% url "api:votedetail" 12345 %}'.replace(/12345/, voteid),
+              data: {
+                post: postid,
+                up: caststatus
+              },
+              beforeSend: function(xhr) {
+                xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+              }
+            }).done(function (msg) {
+              casteractive = true;
+            });
+          }
+        }
+      }
+    }
+    </script>
+    <div class="recommended-posts">
+      {% if recommended_posts %}
+        {% for post in recommended_posts %}
+        <div class="group-detail-content">
+          <!-- Post Start -->
+          <div class="header">
+            <div class="text">
+              <p class="title"><strong>{{ post.owner.username }}</strong></p>
+              <p class="subtitle"><small>Shared in <i>{{ post.group.name }}</i></small></p>
+            </div>
+            <div class="img">
+              <img src="{% static 'assets/img/user.jpg' %}" alt="User placeholder" class="img-circle avatar">
+            </div>
+          </div>
+          <div class="content">
+            {% for question_response in post.data %}
+            <p><strong>{{ question_response.question }}</strong>: <span>{{ question_response.response }}</span></p>
+            {% endfor %}
+          </div>
+          <!-- Post Start -->
+          <div style="display: flex">
+            <!-- Votes Start -->
+            <div data-post-id="{{ post.id }}" data-vote-id="{{ post|vote_of_user:user.id }}" id="post-{{post.id}}" class="votecaster">
+              <span class="vote-count">{{ post|vote_sum }}</span>
+              <span title="+1 Vote Up" class="fa fa-chevron-up vote vote-up"></span>
+              <span title="-1 Vote Down" class="fa fa-chevron-down vote vote-down"></span>
+            </div><script type="text/javascript">votecaster_onload(document.getElementById("post-{{post.id}}"));</script>
+            <!-- Votes Start -->
+  
+            <!-- Comments Header Start -->
+            <div class="comments-header">
+              <a class="text-muted" onclick="$(this).parent().parent().next().slideToggle()" href="javascript:void(0);">
+                {{ post.comments|length }} Comment{{ post.comments|length|pluralize }}
+              </a>
+            </div>
+            <!-- Comments Header End -->
+          </div>
+  
+          <!-- Comments Contents Start -->
+          <div class="comments-contents" style="display: none">
+            <!-- <div class="form-group" id="commentForm{{post.id}}">
+              <input name="text" class="form-control" id="comment-text-post-{{post.id}}" type="text" onkeypress="submitComment(event,this)" placeholder="Press Enter to send your comment!">
+            </div> -->
+  
+            <div class="comments-old-contents" style="text-align: left">
+                {% for comment in post.comments.all%}
+                   <hr> </hr>
+                   <p style="font-size: 14px">{{ comment.text }} - <span style="color: #3af">{{comment.owner.username }}</span> <span style="color: #9199a1">{{comment.created}}</span></p>
+                {% endfor %}
+            </div>
+          </div>
+          <!-- Comments Contents End -->
+  
+        </div>
+        {% endfor %}
+      {% else %}
+        No recommended posts!
       {% endif %}
     </div>
   </div>

--- a/api/interestr/website/templatetags/voting_extras.py
+++ b/api/interestr/website/templatetags/voting_extras.py
@@ -5,8 +5,9 @@ register = template.Library()
 
 @register.filter
 def vote_of_user(post, user):
-    vote = Vote.objects.filter(owner__pk=user, post__pk=post.id).first()
+    vote = Vote.objects.filter(owner__pk=user, post__pk=post['id'] if isinstance(post, dict) else post.id).first()
     return vote.id if vote else -1
 
-    # qs = post.votes.filter(owner__pk=user)
-    # return qs.first().id if qs.exists() else -1
+@register.filter
+def vote_sum(post):
+    return len(filter(lambda v: v['up'], post['votes'])) - len(filter(lambda v: not v['up'], post['votes']))

--- a/api/interestr/website/views.py
+++ b/api/interestr/website/views.py
@@ -116,7 +116,7 @@ class HomePageView(View):
 
     def dispatch(self, request, *args, **kwargs):
         if request.user.is_authenticated():
-            return redirect('website:groups')
+            return redirect('website:news')
         return super(HomePageView, self).dispatch(request, *args, **kwargs)
 
     def get(self, request):

--- a/api/interestr/website/views.py
+++ b/api/interestr/website/views.py
@@ -16,7 +16,9 @@ from django.contrib.auth.models import User
 from django.views import View
 
 from api.models import Group, ProfilePage
+from api.views import recommend_groups, recommend_posts
 from .forms import LoginForm, RegisterForm, CreateGroupForm, ProfileForm
+import json
 
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Q
@@ -160,8 +162,10 @@ class CreateGroupView(View):
 class NewsView(LoginRequiredMixin, generic.ListView):
     template_name = 'website/news.html'
 
-    def get_queryset(self):
-        return None
+    def get(self, request):
+        groups = json.loads(recommend_groups(request).content)['results']
+        posts = json.loads(recommend_posts(request).content)['results']
+        return render(request, self.template_name, {'recommended_groups': groups, 'recommended_posts': posts})
 
 class SearchView(LoginRequiredMixin, generic.ListView):
     template_name = 'website/search.html'

--- a/api/interestr/website/views.py
+++ b/api/interestr/website/views.py
@@ -29,7 +29,7 @@ class UserLoginView(View):
 
     def dispatch(self, request, *args, **kwargs):
         if request.user.is_authenticated():
-            return redirect('website:groups')
+            return redirect('website:news')
         return super(UserLoginView, self).dispatch(request, *args, **kwargs)
 
     #display blank form
@@ -58,7 +58,7 @@ class UserLoginView(View):
                 if user is not None:
                         if user.is_active: #if he/she is not banned
                                 login(request,user)
-                                return redirect('website:groups')
+                                return redirect('website:news')
 
                 return render(request,self.template_name, {'err_msg': 'Invalid credentials!'})
 


### PR DESCRIPTION
## About

* **Related Issues:** #175 #184 #141 

Now we display the group and post recommendations in the news feed. This PR also includes some bug fixes and minor improvements.

Closes #175 

### Changes

- Implement the post and group recommendations UI.
- Fix the voting feature.
  - Set the owner of the vote on the backend.
  - Split the serializer into two: `VoteCreateSerializer` and `VoteSerializer`.
- Use serializers in the recommendation endpoints instead of manually selecting which fields to return.
- Redirect the user to the news feed on login and signup instead of the groups page.


## Visuals

|Recommendations for user 1|Recommendations for user 2|
|---|---|
|![screencapture-127-0-0-1-8000-news-1513463201726](https://user-images.githubusercontent.com/13895224/34074892-037656f8-e2ca-11e7-97e4-60bcac1f5af4.png)|![screencapture-127-0-0-1-8000-news-1513463108847](https://user-images.githubusercontent.com/13895224/34074893-03967b86-e2ca-11e7-8643-80f3cb1ca362.png)|

## Testing

- Go to the news feed page.
- You should see your recommended groups and posts, and you should be able to interact with them (cast votes, add comments etc.) without any problems.
