### PR TITLE
Data Template Validation

### DIFF
--- a/api/interestr/api/serializers.py
+++ b/api/interestr/api/serializers.py
@@ -34,10 +34,55 @@ class DataTemplateIdNameFieldsSerializer(serializers.ModelSerializer):
 
 class DataTemplateSimpleSerializer(serializers.ModelSerializer):
 
+    VALID_TYPES = [
+        'checkbox',
+        'multisel',
+        'textarea',
+        'text',
+        'number',
+        'date',
+        'email',
+        'url',
+        'tel'
+    ]
+
     class Meta:
         model = core_models.DataTemplate
         fields = ('id', 'name', 'group', 'user',
                   'created', 'updated', 'fields')
+
+    def validate_fields(self, value):
+        """
+        Check that fields value is in correct format.
+        """
+        
+        errors = []
+
+        for field in value:
+            try:
+                i = 0
+                fieldType = field['type']
+                fieldLegend = field['legend']
+                fieldInputs = field['inputs']
+
+                if fieldType not in self.VALID_TYPES:
+                    errors.append("In the field[%d]: 'type' should be one of these: [ %s ]" % (i, ", ".join(self.VALID_TYPES)))
+
+                if not isinstance(fieldLegend, basestring):
+                    errors.append("In the field[%d]: 'legend' must be a string" % i)
+
+                if not fieldLegend.strip():
+                    errors.append("In the field[%d]: 'legend' must not be empty" % i)
+
+
+                i = i + 1
+            except KeyError:
+                errors.append("In the field[%d]: Elements should have 'type', 'legend' and 'inputs' fields." % i)
+
+        if errors:
+            raise serializers.ValidationError(errors)
+
+        return value
 
 
 class DataTemplateSerializer(serializers.ModelSerializer):

--- a/api/interestr/api/serializers.py
+++ b/api/interestr/api/serializers.py
@@ -56,12 +56,11 @@ class DataTemplateSimpleSerializer(serializers.ModelSerializer):
         """
         Check that fields value is in correct format.
         """
+        errors = []
         
         if not value:
             errors.append("Template should have at least one field")
         else:
-            errors = []
-            
             legends = []
 
             i = 0

--- a/api/interestr/api/tests.py
+++ b/api/interestr/api/tests.py
@@ -130,6 +130,43 @@ class PostTests(TestCase):
         except KeyError:
             self.fail('Data Template object should have field \'owner\'')
 
+    def test_create_post_with_no_relation_to_template(self):
+        self.client.force_authenticate(self.test_user)
+
+        post_data = {
+            'group': self.test_group.id,
+            'data_template': self.test_data_template.id,
+            'data': [
+                {
+                    'question': 'Question, lel',
+                    'response': 'Response, lel'
+                }
+            ]
+        }
+
+        response = self.client.post('/api/v1/posts/', post_data, format='json')
+
+        self.assertEqual(response.status_code, 400,
+                         responseError(response, 'Create Post with no relation to the template', False))
+
+    def test_create_post_with_invalid_data(self):
+        self.client.force_authenticate(self.test_user)
+
+        post_data = {
+            'group': self.test_group.id,
+            'data_template': self.test_data_template.id,
+            'data': [
+                {
+                    'invalid': 'invalid'
+                }
+            ]
+        }
+
+        response = self.client.post('/api/v1/posts/', post_data, format='json')
+
+        self.assertEqual(response.status_code, 400,
+                         responseError(response, 'Create Post with invalid data', False))
+
     def test_update_post(self):
         self.client.force_authenticate(self.test_user)
 
@@ -422,6 +459,37 @@ class DataTemplateTests(TestCase):
                                     template_fields, format='json')
         self.assertEqual(response.status_code, 400,
                          responseError(response, 'Create Wrong Type Data Template', False))
+
+    def test_create_multiple_field_same_legend_template(self):
+        self.client.force_authenticate(user=self.test_user)
+        template_fields = {
+            'name': 'Basic template',
+            'fields': [
+                {
+                    'type': 'text',
+                    'legend': 'SameLegend',
+                    'inputs': [
+                        {
+                            'type': 'text'
+                        }
+                    ]
+                },
+                {
+                    'type': 'text',
+                    'legend': 'SameLegend',
+                    'inputs': [
+                        {
+                            'type': 'text'
+                        }
+                    ]
+                }
+                ],
+            'group': self.test_group.id
+        }
+        response = self.client.post('/api/v1/data_templates/',
+                                    template_fields, format='json')
+        self.assertEqual(response.status_code, 400,
+                         responseError(response, 'Create Multiple Field Same Legend Data Template', False))
 
     def test_existing_template(self):
         response = self.client.get(

--- a/api/interestr/api/tests.py
+++ b/api/interestr/api/tests.py
@@ -372,13 +372,72 @@ class DataTemplateTests(TestCase):
         self.client.force_authenticate(user=self.test_user)
         template_fields = {
             'name': 'Basic template',
-            'fields': ['short_text', 'long_text'],
+            'fields': [{
+                'type': 'text',
+                'legend': 'Title',
+                'inputs': [
+                    {
+                        'type': 'text'
+                    }
+                ]
+            }],
             'group': self.test_group.id
         }
         response = self.client.post('/api/v1/data_templates/',
                                     template_fields, format='json')
         self.assertEqual(response.status_code, 201,
                          responseError(response, 'Create Data Template'))
+
+    def test_create_wrong_format_template(self):
+        self.client.force_authenticate(user=self.test_user)
+        template_fields = {
+            'name': 'Wrong Basic Template',
+            'fields': [{
+                'wrong': 'wrong'
+            }],
+            'group': self.test_group.id
+        }
+
+        response = self.client.post('/api/v1/data_templates/',
+                                    template_fields, format='json')
+        self.assertEqual(response.status_code, 400,
+                         responseError(response, 'Create Wrong Format Data Template', False))
+
+    def test_create_wrong_type_template(self):
+        self.client.force_authenticate(user=self.test_user)
+        template_fields = {
+            'name': 'Basic template',
+            'fields': [{
+                'type': 'wrong',
+                'legend': 'Title',
+                'inputs': [
+                    {
+                        'type': 'text'
+                    }
+                ]
+            }],
+            'group': self.test_group.id
+        }
+        response = self.client.post('/api/v1/data_templates/',
+                                    template_fields, format='json')
+        self.assertEqual(response.status_code, 400,
+                         responseError(response, 'Create Wrong Type Data Template', False))
+
+    def test_create_empty_inputs_template(self):
+        self.client.force_authenticate(user=self.test_user)
+        template_fields = {
+            'name': 'Basic template',
+            'fields': [{
+                'type': 'wrong',
+                'legend': 'Title',
+                'inputs': []
+            }],
+            'group': self.test_group.id
+        }
+        response = self.client.post('/api/v1/data_templates/',
+                                    template_fields, format='json')
+        self.assertEqual(response.status_code, 400,
+                         responseError(response, 'Create Empty Inputs Data Template', False))
 
     def test_existing_template(self):
         response = self.client.get(

--- a/api/interestr/api/tests.py
+++ b/api/interestr/api/tests.py
@@ -130,7 +130,7 @@ class PostTests(TestCase):
         except KeyError:
             self.fail('Data Template object should have field \'owner\'')
 
-    def test_create_post_with_no_relation_to_template(self):
+    def test_create_post_disagreeing_with_its_template(self):
         self.client.force_authenticate(self.test_user)
 
         post_data = {
@@ -475,11 +475,11 @@ class DataTemplateTests(TestCase):
                     ]
                 },
                 {
-                    'type': 'text',
+                    'type': 'textarea',
                     'legend': 'SameLegend',
                     'inputs': [
                         {
-                            'type': 'text'
+                            'type': 'textarea'
                         }
                     ]
                 }

--- a/api/interestr/api/tests.py
+++ b/api/interestr/api/tests.py
@@ -423,22 +423,6 @@ class DataTemplateTests(TestCase):
         self.assertEqual(response.status_code, 400,
                          responseError(response, 'Create Wrong Type Data Template', False))
 
-    def test_create_empty_inputs_template(self):
-        self.client.force_authenticate(user=self.test_user)
-        template_fields = {
-            'name': 'Basic template',
-            'fields': [{
-                'type': 'wrong',
-                'legend': 'Title',
-                'inputs': []
-            }],
-            'group': self.test_group.id
-        }
-        response = self.client.post('/api/v1/data_templates/',
-                                    template_fields, format='json')
-        self.assertEqual(response.status_code, 400,
-                         responseError(response, 'Create Empty Inputs Data Template', False))
-
     def test_existing_template(self):
         response = self.client.get(
             '/api/v1/data_templates/' + str(self.test_data_template.id) + '/')


### PR DESCRIPTION
## About

Don't know why, but decided to work on this stuff...

The frontend for the default template stuff is broken if it relies on the API side of the project. Because it was relying on putting null to the template field. I think we should not allow null template field. A group should be created with a 'default' template. I'll leave this for now and return to building android.

### Changes

- Data Templates are now checked for compliance to the template docs
- Posts are now checked if they are fitting with their data template

## Visuals
![image](https://user-images.githubusercontent.com/5247569/34083273-828df7ac-e37e-11e7-93ea-58138a0f0e40.png)