### PR TITLE
Template based search UI

### DIFF
--- a/api/interestr/website/static/assets/css/custom.css
+++ b/api/interestr/website/static/assets/css/custom.css
@@ -63,7 +63,7 @@ small {
 }
 
 .nav-search {
-  width: 200px;
+  width: 310px;
 }
 
 .nav-search > input {

--- a/api/interestr/website/static/assets/css/custom.css
+++ b/api/interestr/website/static/assets/css/custom.css
@@ -63,7 +63,7 @@ small {
 }
 
 .nav-search {
-  width: 310px;
+  width: 200px;
 }
 
 .nav-search > input {

--- a/api/interestr/website/templates/website/base.html
+++ b/api/interestr/website/templates/website/base.html
@@ -43,7 +43,7 @@
       window.search = function() {
         var searchQuery = $("#search-input").val();
         if (!searchQuery.length) {
-          swal('Sorry...', 'Please enter at least 1 character to search.', 'error');
+          window.location.href = "{% url 'website:search_advanced' %}";
           return;
         }
         window.location.href = "{% url 'website:search' %}?q=" + searchQuery;

--- a/api/interestr/website/templates/website/base.html
+++ b/api/interestr/website/templates/website/base.html
@@ -39,11 +39,12 @@
       }
       return cookieValue;
     }
+
     window.onload = function() {
       window.search = function() {
         var searchQuery = $("#search-input").val();
         if (!searchQuery.length) {
-          window.location.href = "{% url 'website:search_advanced' %}";
+          swal('Sorry...', 'Please enter at least 1 character to search.', 'error');
           return;
         }
         window.location.href = "{% url 'website:search' %}?q=" + searchQuery;

--- a/api/interestr/website/templates/website/create-group.html
+++ b/api/interestr/website/templates/website/create-group.html
@@ -6,7 +6,7 @@
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
     <li class="nav-search">
-      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
     </li>
     <li>
       <a href="javascript:void(0);" onclick="window.search()">

--- a/api/interestr/website/templates/website/create-group.html
+++ b/api/interestr/website/templates/website/create-group.html
@@ -5,8 +5,9 @@
 {% block navbaritems %}
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
+    <li><a href="{% url 'website:search_advanced' %}">Advanced Search</a></li>
     <li class="nav-search">
-      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
     </li>
     <li>
       <a href="javascript:void(0);" onclick="window.search()">

--- a/api/interestr/website/templates/website/group-details.html
+++ b/api/interestr/website/templates/website/group-details.html
@@ -1,6 +1,6 @@
 {% extends 'website/base.html' %}
 
-{% load voting_extras %}
+{% load filters %}
 {% load static %}
 
 {% block title %}Group Page{% endblock %}
@@ -9,7 +9,7 @@
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
     <li class="nav-search">
-      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
     </li>
     <li>
       <a href="javascript:void(0);" onclick="window.search()">

--- a/api/interestr/website/templates/website/group-details.html
+++ b/api/interestr/website/templates/website/group-details.html
@@ -8,8 +8,9 @@
 {% block navbaritems %}
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
+    <li><a href="{% url 'website:search_advanced' %}">Advanced Search</a></li>
     <li class="nav-search">
-      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
     </li>
     <li>
       <a href="javascript:void(0);" onclick="window.search()">

--- a/api/interestr/website/templates/website/groups.html
+++ b/api/interestr/website/templates/website/groups.html
@@ -6,7 +6,7 @@
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
     <li class="nav-search">
-      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
     </li>
     <li>
       <a href="javascript:void(0);" onclick="window.search()">

--- a/api/interestr/website/templates/website/groups.html
+++ b/api/interestr/website/templates/website/groups.html
@@ -5,8 +5,9 @@
 {% block navbaritems %}
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
+    <li><a href="{% url 'website:search_advanced' %}">Advanced Search</a></li>
     <li class="nav-search">
-      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
     </li>
     <li>
       <a href="javascript:void(0);" onclick="window.search()">

--- a/api/interestr/website/templates/website/my_profile.html
+++ b/api/interestr/website/templates/website/my_profile.html
@@ -6,7 +6,7 @@
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
     <li class="nav-search">
-      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
     </li>
     <li>
       <a href="javascript:void(0);" onclick="window.search()">

--- a/api/interestr/website/templates/website/my_profile.html
+++ b/api/interestr/website/templates/website/my_profile.html
@@ -5,8 +5,9 @@
 {% block navbaritems %}
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
+    <li><a href="{% url 'website:search_advanced' %}">Advanced Search</a></li>
     <li class="nav-search">
-      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
     </li>
     <li>
       <a href="javascript:void(0);" onclick="window.search()">

--- a/api/interestr/website/templates/website/news.html
+++ b/api/interestr/website/templates/website/news.html
@@ -214,7 +214,7 @@
           <div class="header">
             <div class="text">
               <p class="title"><strong>{{ post.owner.username }}</strong></p>
-              <p class="subtitle"><small>Shared in <i>{{ post.group.name }}</i></small></p>
+              <p class="subtitle"><small>Shared in <i><a href="{% url "website:group_details" post.group.id %}">{{ post.group.name }}</a></i></small></p>
             </div>
             <div class="img">
               <img src="{% static 'assets/img/user.jpg' %}" alt="User placeholder" class="img-circle avatar">

--- a/api/interestr/website/templates/website/news.html
+++ b/api/interestr/website/templates/website/news.html
@@ -8,8 +8,9 @@
 {% block navbaritems %}
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
+    <li><a href="{% url 'website:search_advanced' %}">Advanced Search</a></li>
     <li class="nav-search">
-      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
     </li>
     <li>
       <a href="javascript:void(0);" onclick="window.search()">

--- a/api/interestr/website/templates/website/news.html
+++ b/api/interestr/website/templates/website/news.html
@@ -1,7 +1,7 @@
 {% extends 'website/base.html' %}
 
 {% load staticfiles %}
-{% load voting_extras %}
+{% load filters %}
 
 {% block title %}News Feed{% endblock %}
 
@@ -9,7 +9,7 @@
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
     <li class="nav-search">
-      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
     </li>
     <li>
       <a href="javascript:void(0);" onclick="window.search()">

--- a/api/interestr/website/templates/website/profile.html
+++ b/api/interestr/website/templates/website/profile.html
@@ -6,7 +6,7 @@
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
     <li class="nav-search">
-      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
     </li>
     <li>
       <a href="javascript:void(0);" onclick="window.search()">

--- a/api/interestr/website/templates/website/profile.html
+++ b/api/interestr/website/templates/website/profile.html
@@ -5,8 +5,9 @@
 {% block navbaritems %}
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
+    <li><a href="{% url 'website:search_advanced' %}">Advanced Search</a></li>
     <li class="nav-search">
-      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
     </li>
     <li>
       <a href="javascript:void(0);" onclick="window.search()">

--- a/api/interestr/website/templates/website/search.html
+++ b/api/interestr/website/templates/website/search.html
@@ -6,7 +6,7 @@
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
     <li class="nav-search">
-      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
     </li>
     <li>
       <a href="javascript:void(0);" onclick="window.search()">

--- a/api/interestr/website/templates/website/search.html
+++ b/api/interestr/website/templates/website/search.html
@@ -5,8 +5,9 @@
 {% block navbaritems %}
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
+    <li><a href="{% url 'website:search_advanced' %}">Advanced Search</a></li>
     <li class="nav-search">
-      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
     </li>
     <li>
       <a href="javascript:void(0);" onclick="window.search()">

--- a/api/interestr/website/templates/website/search_advanced.html
+++ b/api/interestr/website/templates/website/search_advanced.html
@@ -67,7 +67,7 @@
             </li>
             {% for template in data_templates %}
             <li>
-              <a href="javascript:void(0);" onclick="selectTemplate('{{ template|jsonify }}')">{{ template.name }}</a>
+              <a href="javascript:void(0);" onclick="selectTemplate('{{ template|jsonify }}')">{{ template.name }} ({{ template.group.name }})</a>
             </li>
             {% endfor %}
           </ul>
@@ -112,11 +112,16 @@
   const searchResults = $('#search-results');
   const spinner = $('#spinner');
 
+  let spinnerShowTimeout;
   $(document)
     .ajaxStart(function () {
-      spinner.show();
+      // Only show the spinner if the request won't complete in a second.
+      spinnerShowTimeout = setTimeout(() => {
+        spinner.show();
+      }, 1000);
     })
     .ajaxStop(function () {
+      clearTimeout(spinnerShowTimeout);
       spinner.hide();
     });
 
@@ -177,8 +182,7 @@
 
   function removeConstraint(i) {
     $(`#constraint-${i}`).remove();
-    numConstraints--;
-    
+    constraints[i] = undefined;
   }
 
   function selectTemplate(templateStr) {
@@ -251,14 +255,12 @@
   }
 
   function makeAdvancedSearch() {
-    console.log(`Searching: ${JSON.stringify(constraints)} for template ${selectedTemplate.id}`);
-    
     $.ajax({
       method: 'POST',
       url: '{% url "api:templatesearch" %}',
       data: JSON.stringify({
         template_id: selectedTemplate.id,
-        constraints: constraints,
+        constraints: constraints.filter(c => !!c), // eliminate the null/undefined values
       }),
       beforeSend: (xhr) => {
         xhr.setRequestHeader("Content-Type", "application/json");

--- a/api/interestr/website/templates/website/search_advanced.html
+++ b/api/interestr/website/templates/website/search_advanced.html
@@ -164,7 +164,7 @@
         </ul>
       </div>
       
-      <input class="data-input" type="text" class="form-control" placeholder="..." size=5 onchange="adjustConstraint(${numConstraints}, 'data', this.value)" />
+      <input class="data-input form-control" type="text" placeholder="..." size=5 onchange="adjustConstraint(${numConstraints}, 'data', this.value)" />
 
       <button class="btn btn-danger" type="button" onclick="removeConstraint(${numConstraints})">-</button>`;  
     const div = document.createElement('div');

--- a/api/interestr/website/templates/website/search_advanced.html
+++ b/api/interestr/website/templates/website/search_advanced.html
@@ -43,7 +43,7 @@
     margin-left: 20px;
   }
 
-  input {
+  .data-input {
     width: 250px !important;
   }
 </style>
@@ -164,7 +164,7 @@
         </ul>
       </div>
       
-      <input id="data-${numConstraints}" type="text" class="form-control" placeholder="..." size=5 onchange="adjustConstraint(${numConstraints}, 'data', this.value)" />
+      <input class="data-input" type="text" class="form-control" placeholder="..." size=5 onchange="adjustConstraint(${numConstraints}, 'data', this.value)" />
 
       <button class="btn btn-danger" type="button" onclick="removeConstraint(${numConstraints})">-</button>`;  
     const div = document.createElement('div');

--- a/api/interestr/website/templates/website/search_advanced.html
+++ b/api/interestr/website/templates/website/search_advanced.html
@@ -1,0 +1,274 @@
+{% extends 'website/base.html' %}
+
+{% load filters %}
+{% load static %}
+
+{% block title %}Search{% endblock %}
+
+{% block navbaritems %}
+<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+  <ul class="nav navbar-nav navbar-right">
+    <li class="nav-search">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
+    </li>
+    <li>
+      <a href="javascript:void(0);" onclick="window.search()">
+        <i class="fa fa-search"></i>
+      </a>
+    </li>
+    <li class="dropdown">
+      <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ user.username }}<b class="caret"></b></a>
+      <ul class="dropdown-menu">
+        <li><a href="{% url 'website:profile' user.id %}">Profile</a></li>
+        <li><a href="{% url 'website:my_profile' %}">Edit Profile</a></li>
+        <li><a href="{% url 'website:news' %}">News Feed</a></li>
+        <li><a href="{% url 'website:groups' %}">Groups</a></li>
+        <li class="divider"></li>
+        <li><a href="{% url 'website:logout' %}">Logout</a></li>
+      </ul>
+    </li>
+  </ul>
+</div>
+{% endblock %}
+
+{% block content %}
+
+<style>
+  .form-group {
+    display: flex;
+    align-items: center;
+  }
+
+  .form-group > :not(:first-child) {
+    margin-left: 20px;
+  }
+
+  input {
+    width: 250px !important;
+  }
+</style>
+
+<div class="main">
+  <div class="container">
+    <h1>Advanced Search</h1>
+    <hr>
+    <div class="advanced-search-form">
+      <div class="form-group">
+        <label for="data-template-dropdown">Data template:</label>
+        <div class="dropdown">
+          <button class="btn btn-round dropdown-toggle" type="button" id="data-template-dropdown" data-toggle="dropdown" aria-haspopup="true"
+            aria-expanded="false">
+            <span id="currentTemplateText">Select a template</span>
+            <b class="caret"></b>
+          </button>
+          <ul class="dropdown-menu" role="menu" aria-labelledby="data-template-dropdown">
+            <li>
+              <a href="javascript:void(0);" onclick="selectTemplate('{&quot;fields&quot;: { &quot;name&quot;: &quot;Default&quot;, &quot;fields&quot;: [{ &quot;legend&quot;: &quot;Text&quot; }]  }}')">Default</a>
+            </li>
+            {% for template in data_templates %}
+            <li>
+              <a href="javascript:void(0);" onclick="selectTemplate('{{ template|jsonify }}')">{{ template.name }}</a>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+
+      <div id="fields">
+      </div>
+
+      <div class="form-group">
+        <button class="btn btn-primary" type="button" onclick="addConstraint()" id="new-constraint-button" style="display:none">
+          + New Constraint
+        </button>
+      </div>
+
+      <div class="form-group">
+        <button class="btn btn-warning" type="button" onclick="makeAdvancedSearch()" id="search-button" style="display:none">
+          Search
+        </button>
+      </div>
+
+      <div class="form-group" style="display:none" id="spinner">
+        <i class="fa fa-cog fa-spin" style="font-size:36px;"></i>
+      </div>
+    </div>
+
+    <div id="results" style="margin-top:20px; display:none">
+      <h1>Search Results</h1>
+      <hr>
+
+      <div id="search-results" class="recommended-posts"></div>
+    </div>
+  </div>
+</div>
+
+<script type="text/javascript">
+  const currentTemplateText = $('#currentTemplateText');
+  const fields = $('#fields');
+  const newConstraintButton = $('#new-constraint-button');
+  const searchButton = $('#search-button');
+  const resultsBlock = $('#results');
+  const searchResults = $('#search-results');
+  const spinner = $('#spinner');
+
+  $(document)
+    .ajaxStart(function () {
+      spinner.show();
+    })
+    .ajaxStop(function () {
+      spinner.hide();
+    });
+
+   // Key: backend value, Value: pretty print
+  const possibleOps = {
+    "greater": "is greater than",
+    "less": "is less than",
+    "equals": "is equal to",
+    "contains": "contains"
+  };
+  let selectedTemplate = null;
+  let numConstraints;
+  let constraints;
+
+  function adjustConstraint(i, key, val, optionText) {
+    constraints[i] = constraints[i] || {};
+    constraints[i][key] = val;
+    if (optionText) {
+      $(`#${key}-${i}-label`).text(optionText);
+    }
+  }
+
+  function addConstraint() {
+    const legendOptions = selectedTemplate.fields.map(f => `<li><a href="javascript:void(0);" onclick="adjustConstraint(${numConstraints}, 'field', '${f.legend}', '${f.legend}')">${f.legend}</a></li>`).join('');
+    const operationOptions = Object.keys(possibleOps).map(op => `<li><a href="javascript:void(0);" onclick="adjustConstraint(${numConstraints}, 'operation', '${op}', '${possibleOps[op]}')">${possibleOps[op]}</a></li>`).join('');
+    const fieldHtml = `
+      <label for="field-${numConstraints}">Field </label>
+      <div class="dropdown">
+        <button class="btn btn-round dropdown-toggle" type="button" id="field-${numConstraints}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <span id="field-${numConstraints}-label">Select a field</span>
+          <b class="caret"></b>
+        </button>
+        <ul class="dropdown-menu" role="menu" aria-labelledby="field-${numConstraints}">
+          ${legendOptions}
+        </ul>
+      </div>
+
+      <div class="dropdown">
+        <button class="btn btn-round dropdown-toggle" type="button" id="operation-${numConstraints}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <span id="operation-${numConstraints}-label">is ...</span>
+          <b class="caret"></b>
+        </button>
+        <ul class="dropdown-menu" role="menu" aria-labelledby="operation-${numConstraints}">
+          ${operationOptions}
+        </ul>
+      </div>
+      
+      <input id="data-${numConstraints}" type="text" class="form-control" placeholder="..." size=5 onchange="adjustConstraint(${numConstraints}, 'data', this.value)" />
+
+      <button class="btn btn-danger" type="button" onclick="removeConstraint(${numConstraints})">-</button>`;  
+    const div = document.createElement('div');
+    div.classList.add('form-group');
+    div.id = `constraint-${numConstraints}`;
+    div.innerHTML = fieldHtml;
+    numConstraints++;
+    fields.append(div);
+  }
+
+  function removeConstraint(i) {
+    $(`#constraint-${i}`).remove();
+    numConstraints--;
+    
+  }
+
+  function selectTemplate(templateStr) {
+    const template = JSON.parse(templateStr);
+    selectedTemplate = {
+      id: template.pk,
+      ...template.fields,
+    };
+    currentTemplateText.text(selectedTemplate.name);
+    fields.html('');
+    constraints = [];
+    numConstraints = 0;
+    addConstraint();
+    newConstraintButton.show();
+    searchButton.show();
+  }
+
+  function loadResults(posts) {
+    searchResults.html('');
+    if (!posts.length) {
+      searchResults.html('No posts found.');
+      return;
+    }
+    for (const post of posts) {
+      const groupDetailUrl = '{% url "website:group_details" 12345 %}';
+      const postHtml = `
+        <!-- Post Start -->
+        <div class="header">
+          <div class="text">
+            <p class="title"><strong>${post.owner.username}</strong></p>
+            <p class="subtitle"><small>Shared in <i><a href="${groupDetailUrl.replace(/12345/, post.group.id)}">${ post.group.name }</a></i></small></p>
+          </div>
+          <div class="img">
+            <img src="{% static 'assets/img/user.jpg' %}" alt="User placeholder" class="img-circle avatar">
+          </div>
+        </div>
+        <div class="content">
+        ${post.data.map(question_response => `<p><strong>${ question_response.question }</strong>: <span>${ question_response.response }</span></p>`).join('')}
+        </div>
+        <!-- Post Start -->
+        <div style="display: flex">
+          <!-- Comments Header Start -->
+          <div class="comments-header">
+            <a class="text-muted" onclick="$(this).parent().parent().next().slideToggle()" href="javascript:void(0);">
+              ${ post.comments.length } Comments
+            </a>
+          </div>
+          <!-- Comments Header End -->
+        </div>
+
+        <!-- Comments Contents Start -->
+        <div class="comments-contents" style="display: none">
+          <!-- <div class="form-group" id="commentForm${post.id}">
+            <input name="text" class="form-control" id="comment-text-post-${post.id}" type="text" onkeypress="submitComment(event,this)" placeholder="Press Enter to send your comment!">
+          </div> -->
+
+          <div class="comments-old-contents" style="text-align: left">
+          ${post.comments.map(comment => `<hr> </hr>
+                <p style="font-size: 14px">${ comment.text } - <span style="color: #3af">${comment.owner.username }</span> <span style="color: #9199a1">${comment.created}</span></p>`).join('')}
+          </div>
+        </div>
+        <!-- Comments Contents End -->
+
+      </div>`;
+      const div = document.createElement('div');
+      div.classList.add('group-detail-content');
+      div.innerHTML = postHtml;
+      searchResults.append(div);
+    }
+  }
+
+  function makeAdvancedSearch() {
+    console.log(`Searching: ${JSON.stringify(constraints)} for template ${selectedTemplate.id}`);
+    
+    $.ajax({
+      method: 'POST',
+      url: '{% url "api:templatesearch" %}',
+      data: JSON.stringify({
+        template_id: selectedTemplate.id,
+        constraints: constraints,
+      }),
+      beforeSend: (xhr) => {
+        xhr.setRequestHeader("Content-Type", "application/json");
+        xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+      }
+    }).done((resp) => {
+      resultsBlock.show();
+      loadResults(resp.results);
+    }).fail((xhr, status, err) => swal('Oops...', 'Unexpected error, couldn\'t send the post.', 'error'));
+  }
+</script>
+
+{% endblock %}

--- a/api/interestr/website/templates/website/search_advanced.html
+++ b/api/interestr/website/templates/website/search_advanced.html
@@ -8,8 +8,9 @@
 {% block navbaritems %}
 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
   <ul class="nav navbar-nav navbar-right">
+    <li><a href="{% url 'website:search_advanced' %}">Advanced Search</a></li>
     <li class="nav-search">
-      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search... (Press Enter for advanced search)" id="search-input">
+      <input type="text" value="{{ search_term }}" class="form-control" placeholder="Search..." id="search-input">
     </li>
     <li>
       <a href="javascript:void(0);" onclick="window.search()">

--- a/api/interestr/website/templatetags/filters.py
+++ b/api/interestr/website/templatetags/filters.py
@@ -1,6 +1,5 @@
 from django import template
 from django.db.models.query import QuerySet
-from django.utils.safestring import mark_safe
 from django.core.serializers import serialize
 from api.models import Post, Vote
 import json

--- a/api/interestr/website/templatetags/filters.py
+++ b/api/interestr/website/templatetags/filters.py
@@ -1,5 +1,9 @@
 from django import template
+from django.db.models.query import QuerySet
+from django.utils.safestring import mark_safe
+from django.core.serializers import serialize
 from api.models import Post, Vote
+import json
 
 register = template.Library()
 
@@ -11,3 +15,9 @@ def vote_of_user(post, user):
 @register.filter
 def vote_sum(post):
     return len(filter(lambda v: v['up'], post['votes'])) - len(filter(lambda v: not v['up'], post['votes']))
+
+@register.filter
+def jsonify(obj):
+    if isinstance(obj, QuerySet):
+        return serialize('json', obj)
+    return json.dumps(json.loads(serialize('json', [obj]))[0])

--- a/api/interestr/website/urls.py
+++ b/api/interestr/website/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     url(r'^logout/$', views.LogoutView.as_view(), name='logout'),
     url(r'^news/$', views.NewsView.as_view(), name='news'),
     url(r'^search/$', views.SearchView.as_view(), name='search'),
+    url(r'^search_advanced/$', views.SearchAdvancedView.as_view(), name='search_advanced'),
     url(r'^profile/$', views.MyProfileView.as_view(), name='my_profile'),
     url(r'^profile/(?P<pk>\d+)/$', views.ProfileView.as_view(), name='profile'),
     url(r'^groups/(?P<pk>\d+)/$', views.GroupDetailsView.as_view(), name='group_details'),

--- a/api/interestr/website/views.py
+++ b/api/interestr/website/views.py
@@ -180,6 +180,12 @@ class SearchView(LoginRequiredMixin, generic.ListView):
             users = users.filter(Q(username__icontains=query)).distinct()
         return render(request, self.template_name, {'groups': groups, 'users': users, 'search_term': query})
 
+class SearchAdvancedView(LoginRequiredMixin, generic.ListView):
+    template_name = 'website/search_advanced.html'
+
+    def get(self, request):
+        data_templates = [data_template for group in request.user.joined_groups.all() for data_template in group.data_templates.all()]
+        return render(request, self.template_name, {'data_templates': data_templates})
 
 class MyProfileView(LoginRequiredMixin, View):
     form_class = ProfileForm

--- a/api/interestr/website/views.py
+++ b/api/interestr/website/views.py
@@ -184,7 +184,7 @@ class SearchAdvancedView(LoginRequiredMixin, generic.ListView):
     template_name = 'website/search_advanced.html'
 
     def get(self, request):
-        data_templates = [data_template for group in request.user.joined_groups.all() for data_template in group.data_templates.all()]
+        data_templates = [data_template for group in Group.objects.all() for data_template in group.data_templates.all()]
         return render(request, self.template_name, {'data_templates': data_templates})
 
 class MyProfileView(LoginRequiredMixin, View):

--- a/fe/create-group.html
+++ b/fe/create-group.html
@@ -40,7 +40,7 @@
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
           <ul class="nav navbar-nav navbar-right">
             <li class="nav-search">
-              <input type="text" value="" class="form-control" placeholder="Search...">
+              <input type="text" value="" class="form-control" placeholder="Search... (Press Enter for advanced search)">
             </li>
             <li>
               <a href="javascript:void(0);">

--- a/fe/create-group.html
+++ b/fe/create-group.html
@@ -39,8 +39,9 @@
 
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
           <ul class="nav navbar-nav navbar-right">
+            <li><a href="{% url 'website:search_advanced' %}">Advanced Search</a></li>
             <li class="nav-search">
-              <input type="text" value="" class="form-control" placeholder="Search... (Press Enter for advanced search)">
+              <input type="text" value="" class="form-control" placeholder="Search...">
             </li>
             <li>
               <a href="javascript:void(0);">

--- a/fe/group-details.html
+++ b/fe/group-details.html
@@ -40,7 +40,7 @@
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
           <ul class="nav navbar-nav navbar-right">
             <li class="nav-search">
-              <input type="text" value="" class="form-control" placeholder="Search...">
+              <input type="text" value="" class="form-control" placeholder="Search... (Press Enter for advanced search)">
             </li>
             <li>
               <a href="javascript:void(0);">

--- a/fe/group-details.html
+++ b/fe/group-details.html
@@ -39,8 +39,9 @@
 
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
           <ul class="nav navbar-nav navbar-right">
+            <li><a href="{% url 'website:search_advanced' %}">Advanced Search</a></li>
             <li class="nav-search">
-              <input type="text" value="" class="form-control" placeholder="Search... (Press Enter for advanced search)">
+              <input type="text" value="" class="form-control" placeholder="Search...">
             </li>
             <li>
               <a href="javascript:void(0);">

--- a/fe/groups.html
+++ b/fe/groups.html
@@ -40,7 +40,7 @@
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
           <ul class="nav navbar-nav navbar-right">
             <li class="nav-search">
-              <input type="text" value="" class="form-control" placeholder="Search...">
+              <input type="text" value="" class="form-control" placeholder="Search... (Press Enter for advanced search)">
             </li>
             <li>
               <a href="javascript:void(0);">

--- a/fe/groups.html
+++ b/fe/groups.html
@@ -39,8 +39,9 @@
 
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
           <ul class="nav navbar-nav navbar-right">
+            <li><a href="{% url 'website:search_advanced' %}">Advanced Search</a></li>
             <li class="nav-search">
-              <input type="text" value="" class="form-control" placeholder="Search... (Press Enter for advanced search)">
+              <input type="text" value="" class="form-control" placeholder="Search...">
             </li>
             <li>
               <a href="javascript:void(0);">


### PR DESCRIPTION
## About

* **Related Issues:** #180 
* **Related Pull Requests:** #200 

Implemented the frontend of the template-based search, i.e. our advanced search feature. This PR contains some other minor changes as well.

### Changes

- Implement the frontend of dynamic template-based search.
- Add a filter called `jsonify` to convert a Django object to a JSON string.
- Add links to group names in recommended posts for easy navigation.

## Visuals

![adv-search](https://user-images.githubusercontent.com/13895224/34343515-a795b174-e9e2-11e7-9de8-ebdc9d9fd064.gif)

**Edit:**
1. Advanced search is a navbar item now:
<img width="592" alt="screen shot 2017-12-27 at 00 58 50" src="https://user-images.githubusercontent.com/13895224/34365448-632c120c-eaa1-11e7-9862-b3347e9cc050.png">

2. Data template selectbox options now include the group names, because groups can have templates with the same name:
<img width="353" alt="screen shot 2017-12-27 at 01 01 34" src="https://user-images.githubusercontent.com/13895224/34365474-a3400a60-eaa1-11e7-8f20-370b368c9384.png">

## Testing

- Log in to our web app.
- Focus on the search input in the navbar and click `Enter` - it should redirect you to the advanced search page.
- Select a data template and add some constraints.
- Click the `Search` button - the page should display a loading icon while making the request, and then display your results. Check the correctness of the results by making the same request with Postman or some other tool.